### PR TITLE
#12: canWrite denies access for root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
   - "0.12"
   - "4"
   - "5"

--- a/Store.es6.js
+++ b/Store.es6.js
@@ -44,24 +44,27 @@ const getObjectFromFile = function(id, cb) {
   });
 };
 
+const FILE_EXISTS = fs.constants ? fs.constants.F_OK : fs.F_OK;
+const FILE_IS_WRITABLE = fs.constants ? fs.constants.W_OK : fs.W_OK;
+
 const canWriteToFile = (file, cb) => {
-  fs.access(file, fs.constants.F_OK, (err) => {
+  fs.access(file, FILE_EXISTS, (err) => {
     if (err) {
       return cb(null);
     }
 
-    fs.access(file, fs.constants.W_OK, cb);
+    fs.access(file, FILE_IS_WRITABLE, cb);
   });
 };
 
 const canWriteToFileSync = (file) => {
   try {
-    fs.accessSync(file, fs.constants.F_OK);
+    fs.accessSync(file, FILE_EXISTS);
   } catch (err) {
     return;
   }
 
-  fs.accessSync(file, fs.constants.W_OK);
+  fs.accessSync(file, FILE_IS_WRITABLE);
 };
 
 const saveObjectToFile = function(o, file, cb) {


### PR DESCRIPTION
Remove custom permission check and instead write immediately to file and return potential access error.

All tests pass. Also passes manual testing where root user can save to another user's file, but obviously not the other way around.

Fixes #12.