### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/Store.es6.js
+++ b/Store.es6.js
@@ -5,7 +5,7 @@ Copyright (C) 2012 - 2016 Markus Kohlhase <mail@markus-kohlhase.de>
 import async  from 'async';
 import fs     from 'fs';
 import path   from 'path';
-import uuid   from 'node-uuid';
+import uuid   from 'uuid';
 import mkdirp from 'mkdirp';
 import clone  from 'clone';
 

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "node": ">=0.10"
   },
   "dependencies": {
-    "mkdirp": "~0.5.1",
-    "node-uuid": "~1.4.7",
     "async": "~2.1.2",
-    "clone": "~2.0.0"
+    "clone": "~2.0.0",
+    "mkdirp": "~0.5.1",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "babel": "^6.5.2",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.